### PR TITLE
Add sourcemaps for inspection with devtools

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,8 @@
     "declaration": true,
     "outDir": "./dist",
     "rootDir": "./src",
+    "sourceMap": true,
+    "inlineSources": true,
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
     "jsx": "react-jsx"


### PR DESCRIPTION
This PR adds a couple of attributes to `tsconfig` so that sourcemaps are available when running with devtools. Typical command to open Chrome devtools:

```
npx tsx --inspect src/index.tsx
```